### PR TITLE
Updated NLB Module to act more like ALB Module

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -199,3 +199,59 @@ variable "lifecycle_configuration_rules" {
     **NOTE:** Unless you also set `lifecycle_rule_enabled = false` you will also get the default deprecated rules set on your bucket.
     EOT
 }
+
+
+variable "target_group_name_max_length" {
+  type        = number
+  default     = 32
+  description = "The max length of characters for the target group."
+}
+
+variable "load_balancer_name_max_length" {
+  type        = number
+  default     = 32
+  description = "The max length of characters for the load balancer."
+}
+
+variable "load_balancer_name" {
+  type        = string
+  default     = ""
+  description = "The name for the default load balancer, uses a module label name if left empty"
+}
+
+variable "connection_termination" {
+  type        = bool
+  default     = false
+  description = "Whether to terminate connections at the end of the deregistration timeout"
+}
+
+variable "preserve_client_ip" {
+  type        = bool
+  default     = false
+  description = "Whether client IP preservation is enabled"
+}
+
+variable "stickiness_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether to enable sticky sessions"
+}
+
+variable "stickiness_type" {
+  type        = string
+  default     = null
+  description = "The type of sticky sessions. The only current possible values are lb_cookie, app_cookie for ALBs, source_ip for NLBs, and source_ip_dest_ip, source_ip_dest_ip_proto for GWLBs."
+}
+
+variable "stickiness_cookie_duration" {
+  type        = number
+  default     = null
+  description = "Only used when stickiness_type is lb_cookie. The time period, in seconds, during which requests from a client should be routed to the same target. After this time period expires, the load balancer-generated cookie is considered stale"
+}
+
+variable "stickiness_cookie_name" {
+  type        = string
+  default     = null
+  description = "Name of the application based cookie. Only needed when type is app_cookie"
+}
+


### PR DESCRIPTION
## what
- Honors the `enabled` attribute of the label to skip the module
- Ensures load balancer and security groups are correct length
- Added stickiness options to security group

## why
- Needed to honor `enabled` so it could be used optionally within another module.

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`

